### PR TITLE
Remove "use epoll"

### DIFF
--- a/public/templates/nginx.conf.html
+++ b/public/templates/nginx.conf.html
@@ -4,7 +4,6 @@ worker_processes {{ data.worker_processes }};
 worker_rlimit_nofile 409600;
 
 events {
-    worker_processes auto;
 	worker_connections 4096;
 	multi_accept on;
 }

--- a/public/templates/nginx.conf.html
+++ b/public/templates/nginx.conf.html
@@ -4,6 +4,7 @@ worker_processes {{ data.worker_processes }};
 worker_rlimit_nofile 409600;
 
 events {
+    worker_processes auto;
 	worker_connections 4096;
 	multi_accept on;
 }

--- a/public/templates/nginx.conf.html
+++ b/public/templates/nginx.conf.html
@@ -6,7 +6,6 @@ worker_rlimit_nofile 409600;
 events {
 	worker_connections 4096;
 	multi_accept on;
-	use epoll;
 }
 
 http {


### PR DESCRIPTION
Remove `use epoll`:

Nginx automatically selects most efficient method.
When you say `use epoll`, you make your configs workable only on Linux servers, no *BSD or Windows.
