### PR TITLE
cert key-size, dhparams size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,12 +1539,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1559,17 +1561,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1686,7 +1691,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1698,6 +1704,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1712,6 +1719,7 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1719,12 +1727,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -1743,6 +1753,7 @@
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1823,7 +1834,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1835,6 +1847,7 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1956,6 +1969,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,18 +33,13 @@
 	},
 	"scripts": {
 		"start": "npm run build && http-server",
-
 		"build": "npm run build:scss",
 		"build:prod": "npm run build:scss:prod && npm run autoprefixer",
-
 		"build:scss": "node-sass --source-map=public/assets/css/app.min.css.map resources/scss/app.scss public/assets/css/app.min.css",
 		"build:scss:prod": "node-sass --output-style=compressed resources/scss/app.scss public/assets/css/app.min.css",
-
 		"autoprefixer": "postcss public/assets/css/app.min.css --use autoprefixer --no-map --replace --verbose",
-
 		"test": "start-server-and-test start http://localhost:8080 cypress:run",
 		"test:debug": "start-server-and-test start http://localhost:8080 cypress:open",
-
 		"cypress:run": "cypress run",
 		"cypress:open": "cypress open"
 	}

--- a/public/templates/commands.html
+++ b/public/templates/commands.html
@@ -2,7 +2,7 @@
 ✔ HTTPS --><span ng-if="isHTTPS() && !isSSLProfileModern()"><!--
 
 --><span class="hljs-comment"># <strong>HTTPS</strong>: create Diffie-Hellman keys</span>
-<span class="hljs-section">openssl dhparam</span> <span class="hljs-attribute">-dsaparam</span> <span class="hljs-attribute">-out</span> /etc/nginx/dhparam.pem <span class="hljs-number">{{ isSSLProfileOld() ? 1024 : 2048 }}</span><!--
+<span class="hljs-section">openssl dhparam</span> <span class="hljs-attribute">-dsaparam</span> <span class="hljs-attribute">-out</span> /etc/nginx/dhparam.pem <span class="hljs-number">{{ isSSLProfileOld() ? 1024 : 4096 }}</span><!--
 
 --><span ng-if="isCertLetsEncrypt()">
 
@@ -23,6 +23,7 @@
 --><span class="hljs-attribute" tooltips tooltip-template="--webroot-path">-w</span> /var/www/_letsencrypt <!--
 --><span class="hljs-attribute" tooltips tooltip-template="--non-interactive">-n</span> <!--
 --><span class="hljs-attribute">--agree-tos</span> <!--
---><span class="hljs-attribute">--force-renewal</span><!--
+--><span class="hljs-attribute">--force-renewal</span> <!--
+--><span class="hljs-attribute">--rsa-key-size 4096</span><!--
 
 --></span>


### PR DESCRIPTION
Change the dhparam size to 4096 bits instead of 2048 if isSSLProfileOld() is false.
Request certificates with a key size of 4096 bits instead of default.

These changes should result in a higher score on ssllabs.com/ssltest.