### PR TITLE
unblock .well-known

### DIFF
--- a/public/templates/conf/nginxconfig.io/general.conf.html
+++ b/public/templates/conf/nginxconfig.io/general.conf.html
@@ -11,7 +11,7 @@ add_header Content-Security-Policy "{{ data.content_security_policy }}" always;<
 add_header Strict-Transport-Security "max-age=31536000{{ isHSTSSubdomains() ? '; includeSubDomains' : '' }}{{ isHSTSPreload() ? '; preload' : '' }}" always;</span>
 
 # . files
-location ~ /\. {
+location ~ /\.(?!well-known) {
 	deny all;
 }<span ng-if="data.expires_assets && data.expires_assets !== data.expires_media">
 


### PR DESCRIPTION
.well-known is designed for well-known information. Although there was a special rule for Let's Encrypt, other applications may also need it (e.g. Keybase). So we should allow access to it.